### PR TITLE
Organisation: added defunct checkbox

### DIFF
--- a/app/Datagrids/Bulks/OrganisationBulk.php
+++ b/app/Datagrids/Bulks/OrganisationBulk.php
@@ -13,5 +13,10 @@ class OrganisationBulk extends Bulk
         'organisation_id',
         'tags',
         'private_choice',
+        'defunct_choice'
+    ];
+
+    protected $mappings = [
+        'is_defunct'
     ];
 }

--- a/app/Datagrids/Filters/OrganisationFilter.php
+++ b/app/Datagrids/Filters/OrganisationFilter.php
@@ -23,6 +23,7 @@ class OrganisationFilter extends DatagridFilter
                 'placeholder' =>  trans('crud.placeholders.organisation'),
                 'model' => Organisation::class,
             ])
+            ->add('is_defunct')
             ->isPrivate()
             ->hasImage()
             ->hasEntityNotes()

--- a/app/Http/Resources/OrganisationResource.php
+++ b/app/Http/Resources/OrganisationResource.php
@@ -17,6 +17,7 @@ class OrganisationResource extends EntityResource
         return $this->entity([
             'type' => $this->type,
             'organisation_id' => $this->organisation_id,
+            'is_defunct' => (bool) $this->is_defunct,
             'members' => OrganisationMemberResource::collection($this->members()->has('character')->with('character')->get())
         ]);
     }

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -265,6 +265,11 @@ class Organisation extends MiscModel
     {
         return !empty($this->type) || !empty($this->location);
     }
+
+    /**
+     * Get the value of the is_defunct variable
+     * @return bool
+     */
     public function isDefunct(): bool
     {
         return (bool) $this->is_defunct;

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property OrganisationMember[] $members
  * @property Organisation[] $descendants
  * @property Organisation[] $organisations
+ * @property bool $is_defunct
  */
 class Organisation extends MiscModel
 {
@@ -42,12 +43,14 @@ class Organisation extends MiscModel
         'organisation_id',
         'type',
         'is_private',
+        'is_defunct'
     ];
 
     protected $sortable = [
         'name',
         'type',
         'organisation.name',
+        'is_defunct'
     ];
 
     /**
@@ -69,6 +72,7 @@ class Organisation extends MiscModel
     protected $filterableColumns = [
         'location_id',
         'organisation_id',
+        'is_defunct',
     ];
 
     /**
@@ -78,6 +82,7 @@ class Organisation extends MiscModel
     protected $sortableColumns = [
         'organisation.name',
         'location.name',
+        'is_defunct',
     ];
 
     /**
@@ -259,5 +264,9 @@ class Organisation extends MiscModel
     public function showProfileInfo(): bool
     {
         return !empty($this->type) || !empty($this->location);
+    }
+    public function isDefunct(): bool
+    {
+        return (bool) $this->is_defunct;
     }
 }

--- a/database/migrations/2022_06_09_151539_update_organisations_add_defunct.php
+++ b/database/migrations/2022_06_09_151539_update_organisations_add_defunct.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateOrganisationsAddDefunct extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('organisations', function (Blueprint $table) {
+            $table->boolean('is_defunct')->default(0);
+            $table->index('is_defunct');
+
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('organisations', function (Blueprint $table) {
+            $table->dropIndex(['is_defunct']);
+            $table->dropColumn('is_defunct');
+        });
+    }
+}

--- a/resources/api-docs/1.0/organisations.md
+++ b/resources/api-docs/1.0/organisations.md
@@ -48,6 +48,7 @@ The list of returned organisations can be filtered. The available filters are av
             "location_id": 4,
             "organisation_id": 4,
             "type": "Kingdom",
+            "is_defunct": true,
             "members": []
         }
     ]
@@ -84,6 +85,7 @@ To get the details of a single organisation, use the following endpoint.
         "location_id": 4,
         "organisation_id": 4,
         "type": "Kingdom",
+        "is_defunct": true,
         "members": []
     }
 
@@ -141,6 +143,7 @@ To create an organisation, use the following endpoint.
 | `organisation_id` | `integer` | The parent organisation |
 | `location_id` | `integer` | The organisation's location |
 | `tags` | `array` | Array of tag ids |
+| `is_defunct` | `boolean` | If the organisation is defunct |
 | `image_url` | `string` | URL to a picture to be used for the organisation || `entity_image_uuid` | `string` | Gallery image UUID for the entity image (limited to superboosted campaigns) |
 | `entity_header_uuid` | `string` | Gallery image UUID for the entity header (limited to superboosted campaigns) |
 | `is_private` | `boolean` | If the organisation is only visible to `admin` members of the campaign |

--- a/resources/lang/en/organisations.php
+++ b/resources/lang/en/organisations.php
@@ -12,6 +12,7 @@ return [
         'organisation'  => 'Parent Organisation',
         'organisations' => 'Sub Organisations',
         'type'          => 'Type',
+        'is_defunct'    => 'Defunct',
     ],
     'helpers'       => [
         'descendants'   => 'This list contains all organisations which are descendants of this organisation, and not only those directly under it.',
@@ -79,5 +80,8 @@ return [
         'tabs'  => [
             'organisations' => 'Organisations',
         ],
+    ],
+    'hints'         => [
+        'is_defunct'    => 'This organisation is defunct.',
     ],
 ];

--- a/resources/views/cruds/fields/defunct_choice.blade.php
+++ b/resources/views/cruds/fields/defunct_choice.blade.php
@@ -1,0 +1,8 @@
+<div class="form-group">
+    <label for="is_defunct">{{ trans('organisations.fields.is_defunct') }}</label>
+    <select name="is_defunct" class="form-control">
+        <option value=""></option>
+        <option value="0">{{ trans('voyager.generic.no') }}</option>
+        <option value="1">{{ trans('voyager.generic.yes') }}</option>
+    </select>
+</div>

--- a/resources/views/cruds/fields/defunct_choice.blade.php
+++ b/resources/views/cruds/fields/defunct_choice.blade.php
@@ -1,8 +1,8 @@
 <div class="form-group">
-    <label for="is_defunct">{{ trans('organisations.fields.is_defunct') }}</label>
+    <label for="is_defunct">{{ __('organisations.fields.is_defunct') }}</label>
     <select name="is_defunct" class="form-control">
         <option value=""></option>
-        <option value="0">{{ trans('voyager.generic.no') }}</option>
-        <option value="1">{{ trans('voyager.generic.yes') }}</option>
+        <option value="0">{{ __('voyager.generic.no') }}</option>
+        <option value="1">{{ __('voyager.generic.yes') }}</option>
     </select>
 </div>

--- a/resources/views/organisations/_tree.blade.php
+++ b/resources/views/organisations/_tree.blade.php
@@ -41,6 +41,17 @@
             'disableSort' => true,
         ],
         [
+            'label' => '<i class="ra ra-skull" title="' . __('organisations.fields.is_defunct') . '"></i>',
+            'field' => 'is_defunct',
+            'render' => function($model) {
+                if ($model->isDefunct()) {
+                    return '<i class="ra ra-skull" title="' . __('organisations.fields.is_defunct') . '"></i>';
+                }
+                return '';
+            },
+            'class' => 'icon'
+        ],
+        [
             'type' => 'is_private',
         ]
     ],

--- a/resources/views/organisations/_tree.blade.php
+++ b/resources/views/organisations/_tree.blade.php
@@ -41,11 +41,11 @@
             'disableSort' => true,
         ],
         [
-            'label' => '<i class="ra ra-skull" title="' . __('organisations.fields.is_defunct') . '"></i>',
+            'label' => '<i class="fa-solid fa-shop-slash" title="' . __('organisations.fields.is_defunct') . '"></i>',
             'field' => 'is_defunct',
             'render' => function($model) {
                 if ($model->isDefunct()) {
-                    return '<i class="ra ra-skull" title="' . __('organisations.fields.is_defunct') . '"></i>';
+                    return '<i class="fa-solid fa-shop-slash" title="' . __('organisations.fields.is_defunct') . '"></i>';
                 }
                 return '';
             },

--- a/resources/views/organisations/datagrid.blade.php
+++ b/resources/views/organisations/datagrid.blade.php
@@ -35,11 +35,11 @@
             'disableSort' => true,
         ],
         [
-            'label' => '<i class="ra ra-skull" title="' . __('organisations.fields.is_defunct') . '"></i>',
+            'label' => '<i class="fa-solid fa-shop-slash" title="' . __('organisations.fields.is_defunct') . '"></i>',
             'field' => 'is_defunct',
             'render' => function($model) {
                 if ($model->isDefunct()) {
-                    return '<i class="ra ra-skull" title="' . __('organisations.fields.is_defunct') . '"></i>';
+                    return '<i class="fa-solid fa-shop-slash" title="' . __('organisations.fields.is_defunct') . '"></i>';
                 }
                 return '';
             },

--- a/resources/views/organisations/datagrid.blade.php
+++ b/resources/views/organisations/datagrid.blade.php
@@ -35,6 +35,17 @@
             'disableSort' => true,
         ],
         [
+            'label' => '<i class="ra ra-skull" title="' . __('organisations.fields.is_defunct') . '"></i>',
+            'field' => 'is_defunct',
+            'render' => function($model) {
+                if ($model->isDefunct()) {
+                    return '<i class="ra ra-skull" title="' . __('organisations.fields.is_defunct') . '"></i>';
+                }
+                return '';
+            },
+            'class' => 'icon'
+        ],
+        [
             'type' => 'is_private',
         ]
     ],

--- a/resources/views/organisations/form/_entry.blade.php
+++ b/resources/views/organisations/form/_entry.blade.php
@@ -44,6 +44,18 @@
 
 <div class="row">
     <div class="col-md-6">
+        <div class="form-group">
+            {!! Form::hidden('is_defunct', 0) !!}
+            <label>{!! Form::checkbox('is_defunct', 1, $model->is_defunct )!!}
+                {{ __('organisations.fields.is_defunct') }}
+            </label>
+            <p class="help-block">{{ __('organisations.hints.is_defunct') }}</p>
+        </div>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-6">
         @include('cruds.fields.tags')
     </div>
     <div class="col-md-6">

--- a/resources/views/organisations/form/_entry.blade.php
+++ b/resources/views/organisations/form/_entry.blade.php
@@ -46,7 +46,7 @@
     <div class="col-md-6">
         <div class="form-group">
             {!! Form::hidden('is_defunct', 0) !!}
-            <label>{!! Form::checkbox('is_defunct', 1, $model->is_defunct )!!}
+            <label>{!! Form::checkbox('is_defunct', 1, $model->is_defunct ?? '' )!!}
                 {{ __('organisations.fields.is_defunct') }}
             </label>
             <p class="help-block">{{ __('organisations.hints.is_defunct') }}</p>


### PR DESCRIPTION
Created a migration to add is_defunct to the organisation table on the database. Added the ability to mark an organisation as defunct, and sort and filter defunct or non-defunct organisations on the organisations page.