### PR TITLE
A toast warning now pops out

### DIFF
--- a/resources/lang/en/crud.php
+++ b/resources/lang/en/crud.php
@@ -29,6 +29,7 @@ return [
     'alerts'                    => [
         'copy_attribute'    => 'The attribute\'s mention was copied to your clipboard.',
         'copy_mention'      => 'The entity\'s advanced mention was copied to your clipboard.',
+        'copy_invite'       => 'The campaign invite link was copied to your clipboard.',
     ],
     'boosted'                   => 'Boosted',
     'boosted_campaigns'         => 'Boosted Campaigns',

--- a/resources/views/campaigns/_invites.blade.php
+++ b/resources/views/campaigns/_invites.blade.php
@@ -49,7 +49,7 @@
                                         <a href="{{ route('campaigns.join', ['token' => $relation->token]) }}">
                                             {{ substr($relation->token, 0, 6) . '...' }}
                                         </a>
-                                        <a href="#" title="{{ __('campaigns.invites.actions.copy') }}" data-clipboard="{{ route('campaigns.join', ['token' => $relation->token]) }}" data-toggle="tooltip">
+                                        <a href="#" title="{{ __('campaigns.invites.actions.copy') }}" data-clipboard="{{ route('campaigns.join', ['token' => $relation->token]) }}" data-toggle="tooltip" data-toast="{{ __('crud.alerts.copy_invite') }}">
                                             <i class="fa-solid fa-copy"></i>
                                         </a>
                                     @endif


### PR DESCRIPTION
 A toast warning now pops out when an invite link is copied to the clipboard from the members section of a campaign.