### PR TITLE
Refactor calendar dates to not de-sync

### DIFF
--- a/app/Console/Commands/MigrateCalendarDates.php
+++ b/app/Console/Commands/MigrateCalendarDates.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\EntityEvent;
+use App\Models\EntityEventType;
+use App\Models\Journal;
+use App\Models\MiscModel;
+use App\Models\Quest;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class MigrateCalendarDates extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'reminders:migrate';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Migrate calendar date events to have the proper type_id';
+
+    protected int $count = 0;
+    protected int $cleared = 0;
+
+    protected array $reminders = [];
+    protected array $clears = [];
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        Journal::select('journals.*')
+            ->joinEntity()
+            ->leftJoin('entity_events as r', function ($sub) {
+                return $sub
+                    ->on('r.entity_id', 'e.id')
+                    ->where('r.type_id', EntityEventType::CALENDAR_DATE);
+            })
+            ->whereNotNull('journals.calendar_id')
+            ->whereNull('r.id')
+            ->with('entity')
+            ->with('entity.events')
+            ->chunk(1000, function ($journals) {
+                $this->clears = [];
+                $this->reminders = [];
+                foreach ($journals as $journal) {
+                    $this->fix($journal);
+                }
+
+                if (!empty($this->clears)) {
+                    $this->cleared += count($this->clears);
+                    DB::statement('UPDATE journals SET calendar_id = null, calendar_day = null, calendar_month = null, calendar_year = null WHERE id IN (' . implode(', ', $this->clears) . ')');
+                }
+                if (!empty($this->reminders)) {
+                    $this->count += count($this->reminders);
+                    DB::statement('UPDATE entity_events SET type_id = ' . EntityEventType::CALENDAR_DATE . ' WHERE id IN (' . implode(', ', $this->reminders) . ')');
+                }
+            });
+
+        $this->info('Migrated ' . $this->count . ' and cleared ' . $this->cleared . ' journals.');
+
+        Quest::select('quests.*')
+            ->joinEntity()
+            ->leftJoin('entity_events as r', function ($sub) {
+                return $sub
+                    ->on('r.entity_id', 'e.id')
+                    ->where('r.type_id', EntityEventType::CALENDAR_DATE);
+            })
+            ->whereNotNull('quests.calendar_id')
+            ->whereNull('r.id')
+            ->with('entity')
+            ->with('entity.events')
+            ->chunk(1000, function ($quests) {
+                $this->clears = [];
+                $this->reminders = [];
+                foreach ($quests as $quest) {
+                    $this->fix($quest);
+                }
+
+                if (!empty($this->clears)) {
+                    $this->cleared += count($this->clears);
+                    DB::statement('UPDATE quests SET calendar_id = null, calendar_day = null, calendar_month = null, calendar_year = null WHERE id IN (' . implode(', ', $this->clears) . ')');
+                }
+                if (!empty($this->reminders)) {
+                    $this->count += count($this->reminders);
+                    DB::statement('UPDATE entity_events SET type_id = ' . EntityEventType::CALENDAR_DATE . ' WHERE id IN (' . implode(', ', $this->reminders) . ')');
+                }
+            });
+
+        $this->info('Migrated ' . $this->count . ' and cleared ' . $this->cleared . ' quests.');
+    }
+
+    protected function fix(Journal|Quest $model)
+    {
+        // Old code, try and get the first reminder
+        /** @var EntityEvent $reminder */
+        $reminder = $model->entity->calendarDateEvents->first();
+        if (!$reminder) {
+            // No reminder? Might be an entity copied over from one campaign to another, in which case we can reset it
+            $this->clears[] = $model->id;
+            return;
+        }
+        $this->reminders[] = $reminder->id;
+    }
+}

--- a/app/Http/Controllers/Api/v1/MenuLinkApiController.php
+++ b/app/Http/Controllers/Api/v1/MenuLinkApiController.php
@@ -19,6 +19,7 @@ class MenuLinkApiController extends ApiController
         $this->authorize('access', $campaign);
         return Resource::collection($campaign
             ->menuLinks()
+            ->withApi()
             ->lastSync(request()->get('lastSync'))
             ->paginate());
     }

--- a/app/Http/Resources/JournalResource.php
+++ b/app/Http/Resources/JournalResource.php
@@ -20,11 +20,12 @@ class JournalResource extends EntityResource
             'journal_id' => $model->journal_id,
             'date' => $model->date,
             'type' => $model->type,
-            'author_id' => $model->author,
-            'calendar_id' => $model->calendar_id,
-            'calendar_year' => $model->calendar_year,
-            'calendar_month' => $model->calendar_month,
-            'calendar_day' => $model->calendar_day,
+            'author' => $model->author,
+            'author_id' => $model->author_id,
+            'calendar_id' => $model->entity->calendarDate?->calendar_id,
+            'calendar_year' => $model->entity->calendarDate?->year,
+            'calendar_month' => $model->entity->calendarDate?->month,
+            'calendar_day' => $model->entity->calendarDate?->day,
         ]);
     }
 }

--- a/app/Http/Resources/QuestResource.php
+++ b/app/Http/Resources/QuestResource.php
@@ -22,10 +22,10 @@ class QuestResource extends EntityResource
             'is_completed' => $model->isCompleted(),
             'quest_id' => $model->quest_id,
             'character_id' => $model->character_id,
-            'calendar_id' => $model->calendar_id,
-            'calendar_year' => $model->calendar_year,
-            'calendar_month' => $model->calendar_month,
-            'calendar_day' => $model->calendar_day,
+            'calendar_id' => $model->entity->calendarDate?->calendar_id,
+            'calendar_year' => $model->entity->calendarDate?->year,
+            'calendar_month' => $model->entity->calendarDate?->month,
+            'calendar_day' => $model->entity->calendarDate?->day,
             'elements_count' => $model->elements->count(),
             'elements' => QuestElementResource::collection($model->elements)
         ]);

--- a/app/Http/Resources/QuestResource.php
+++ b/app/Http/Resources/QuestResource.php
@@ -19,7 +19,7 @@ class QuestResource extends EntityResource
         return $this->entity([
             'type' => $model->type,
             'date' => $model->date,
-            'is_completed' => (bool) $model->is_completed,
+            'is_completed' => $model->isCompleted(),
             'quest_id' => $model->quest_id,
             'character_id' => $model->character_id,
             'calendar_id' => $model->calendar_id,

--- a/app/Models/Attribute.php
+++ b/app/Models/Attribute.php
@@ -69,7 +69,7 @@ class Attribute extends Model
      * Trigger for filtering based on the order request.
      * @var string
      */
-    protected $orderTrigger = 'attributes/';
+    protected string $orderTrigger = 'attributes/';
 
     /**
      * Searchable fields

--- a/app/Models/Concerns/HasFilters.php
+++ b/app/Models/Concerns/HasFilters.php
@@ -133,8 +133,8 @@ trait HasFilters
                 } elseif ($key == 'location_id') {
                     $this->filterLocations($query, $value, $key);
                 } elseif ($key == 'tag_id') {
-                    $query = $this->joinEntity($query);
                     $query
+                        ->joinEntity()
                         ->leftJoin('entity_tags as et', 'et.entity_id', 'e.id')
                         ->where('et.tag_id', $value);
                 } elseif (in_array($key, ['attribute_value', 'attribute_name'])) {
@@ -162,8 +162,9 @@ trait HasFilters
                 } elseif ($key == 'parent') {
                     $this->filterParent($query);
                 } elseif (in_array($key, ['created_by', 'updated_by'])) {
-                    $query = $this->joinEntity($query);
-                    $query->where('e.' . $key, (int) $value);
+                    $query
+                        ->joinEntity()
+                        ->where('e.' . $key, (int) $value);
                 } elseif ($this->filterOperator === 'IS NULL') {
                     $query->where(function ($sub) use ($key) {
                         $sub->whereNull($this->getTable() . '.' . $key)
@@ -278,7 +279,7 @@ trait HasFilters
         if ($key == 'attribute_value') {
             return;
         }
-        $query = $this->joinEntity($query);
+        $query->joinEntity();
 
         // No attribute with this name
         if ($this->filterOperator === 'not like') {
@@ -351,8 +352,9 @@ trait HasFilters
      */
     protected function filterHasFiles(Builder $query, string $value = null): void
     {
-        $query = $this->joinEntity($query);
-        $query->leftJoin('entity_assets', 'entity_assets.entity_id', '=', 'e.id')
+        $query
+            ->joinEntity()
+            ->leftJoin('entity_assets', 'entity_assets.entity_id', '=', 'e.id')
             ->where('entity_assets.type_id', \App\Models\EntityAsset::TYPE_FILE);
 
         if ($value) {
@@ -385,7 +387,7 @@ trait HasFilters
      */
     protected function filterTemplate(Builder $query, string $value = null): void
     {
-        $query = $this->joinEntity($query);
+        $query->joinEntity();
 
         if ($value) {
             $query->where('e.is_template', 1);
@@ -405,8 +407,9 @@ trait HasFilters
      */
     protected function filterHasPosts(Builder $query, string $value = null): void
     {
-        $query = $this->joinEntity($query);
-        $query->leftJoin('entity_notes', 'entity_notes.entity_id', 'e.id');
+        $query
+            ->joinEntity()
+            ->leftJoin('entity_notes', 'entity_notes.entity_id', 'e.id');
 
         if ($value) {
             $query->whereNotNull('entity_notes.id');
@@ -423,8 +426,9 @@ trait HasFilters
      */
     protected function filterHasAttributes(Builder $query, string $value = null): void
     {
-        $query = $this->joinEntity($query);
-        $query->leftJoin('attributes', 'attributes.entity_id', 'e.id');
+        $query
+            ->joinEntity()
+            ->leftJoin('attributes', 'attributes.entity_id', 'e.id');
 
         if ($value) {
             $query->whereNotNull('attributes.id');
@@ -445,7 +449,9 @@ trait HasFilters
         if ($this->filterOption('none')) {
             return;
         }
-        $query = $this->joinEntity($query);
+        $query
+            ->joinEntity()
+        ;
 
         // Make sure we always have an array
         if (!is_array($value)) {
@@ -569,7 +575,9 @@ trait HasFilters
         if ($this->filterOption('none')) {
             return;
         }
-        $query = $this->joinEntity($query);
+        $query
+            ->joinEntity()
+        ;
 
         // Make sure we always have an array
         if (!is_array($value)) {
@@ -661,8 +669,8 @@ trait HasFilters
                 $query->whereNull($this->getTable() . '.' . $key);
             }
         } elseif ($key === 'tags') {
-            $query = $this->joinEntity($query);
             $query
+                ->joinEntity()
                 ->leftJoin('entity_tags as no_tags', 'no_tags.entity_id', 'e.id')
                 ->whereNull('no_tags.tag_id');
         } elseif ($key === 'race_id') {

--- a/app/Models/Concerns/HasFilters.php
+++ b/app/Models/Concerns/HasFilters.php
@@ -214,7 +214,7 @@ trait HasFilters
      * @param Builder $query
      * @return Builder
      */
-    protected function joinEntity(Builder $query): Builder
+    /*protected function joinEntity(Builder $query): Builder
     {
         if ($this->joinedEntity) {
             return $query;
@@ -233,7 +233,7 @@ trait HasFilters
             })
             ->groupBy($this->getTable() . '.id')
         ;
-    }
+    }*/
 
     /**
      * Add a query on a foreign relationship of the model

--- a/app/Models/Concerns/Orderable.php
+++ b/app/Models/Concerns/Orderable.php
@@ -2,7 +2,9 @@
 
 namespace App\Models\Concerns;
 
+use App\Models\EntityEventType;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
@@ -30,12 +32,18 @@ trait Orderable
             }
         }
 
-        // Calendar dates are handled differently since we have free fields
-        if ($field == 'calendar_date') {
+        // Calendar dates are handled differently since we have three fields.
+        // However, we should do a left join instead
+        if ($field === 'calendar_date') {
             return $query
-                ->orderBy($this->getTable() . '.calendar_year', $direction)
-                ->orderBy($this->getTable() . '.calendar_month', $direction)
-                ->orderBy($this->getTable() . '.calendar_day', $direction);
+                ->joinEntity()
+                ->leftJoin('entity_events as cd', function ($on) {
+                    return $on->on('cd.entity_id', 'e.id')
+                        ->where('cd.type_id', EntityEventType::CALENDAR_DATE);
+                })
+                ->orderBy('cd.year', $direction)
+                ->orderBy('cd.month', $direction)
+                ->orderBy('cd.day', $direction);
         }
 
 

--- a/app/Models/DiceRoll.php
+++ b/app/Models/DiceRoll.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Models\Concerns\Acl;
 use App\Traits\CampaignTrait;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
@@ -110,5 +111,24 @@ class DiceRoll extends MiscModel
         return [
             'character_id',
         ];
+    }
+    /**
+     * Performance with for datagrids
+     * @param Builder $query
+     * @return Builder
+     */
+    public function scopePreparedWith(Builder $query): Builder
+    {
+        return $query->with([
+            'entity' => function ($sub) {
+                $sub->select('id', 'name', 'entity_id', 'type_id', 'image_uuid', 'focus_x', 'focus_y');
+            },
+            'entity.image' => function ($sub) {
+                $sub->select('campaign_id', 'id', 'ext', 'focus_x', 'focus_y');
+            },
+            'character' => function ($sub) {
+                $sub->select('id', 'name');
+            },
+        ]);
     }
 }

--- a/app/Models/Entity.php
+++ b/app/Models/Entity.php
@@ -55,9 +55,6 @@ class Entity extends Model
 {
     use Acl;
     use BlameableTrait;
-    /**
-     * Traits
-     */
     use CampaignTrait;
     use EntityLogs;
     use EntityRelations;

--- a/app/Models/EntityEvent.php
+++ b/app/Models/EntityEvent.php
@@ -29,13 +29,12 @@ use Illuminate\Support\Str;
  * @property integer $elapsed
  * @property boolean $is_private
  *
- * @property Calendar $calendar
- * @property EntityEventType $type
+ * @property Calendar|null $calendar
+ * @property EntityEventType|null $type
  */
 class EntityEvent extends MiscModel
 {
     use Blameable;
-    /** Traits */
     use OrderableTrait;
     use SortableTrait;
     use VisibilityIDTrait;
@@ -44,14 +43,14 @@ class EntityEvent extends MiscModel
      * Trigger for filtering based on the order request.
      * @var string
      */
-    protected $orderTrigger = 'events/';
-    protected $orderDefaultDir = 'desc';
+    protected string $orderTrigger = 'events/';
+    protected string $orderDefaultDir = 'desc';
 
     /** @var string */
     public $table = 'entity_events';
 
-    /** @var string Cached readable date */
-    protected $readableDate;
+    /** @var string|null Cached readable date */
+    protected string|null $readableDate = null;
 
     /** @var string[]  */
     protected $fillable = [
@@ -80,10 +79,10 @@ class EntityEvent extends MiscModel
     ];
 
     /** @var bool|int Last occurence of the reminder */
-    protected $cachedLast = false;
+    protected mixed $cachedLast = false;
 
     /** @var bool|int Next occurence of the reminder */
-    protected $cachedNext = false;
+    protected mixed $cachedNext = false;
 
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/app/Models/EntityEvent.php
+++ b/app/Models/EntityEvent.php
@@ -13,20 +13,20 @@ use Illuminate\Support\Str;
  * Class EntityEvent
  * @package App\Models
  *
- * @property integer $entity_id
- * @property integer $calendar_id
+ * @property int $entity_id
+ * @property int $calendar_id
  * @property string $date
- * @property integer $length
+ * @property int $length
  * @property string $comment
  * @property string $colour
- * @property integer $day
- * @property integer $month
- * @property integer $year
+ * @property int $day
+ * @property int $month
+ * @property int $year
  * @property boolean $is_recurring
- * @property integer|null $recurring_until
+ * @property int|null $recurring_until
  * @property string $recurring_periodicity
- * @property integer $type_id
- * @property integer $elapsed
+ * @property int $type_id
+ * @property int $elapsed
  * @property boolean $is_private
  *
  * @property Calendar|null $calendar

--- a/app/Models/EntityFile.php
+++ b/app/Models/EntityFile.php
@@ -25,11 +25,7 @@ use Illuminate\Support\Str;
 class EntityFile extends Model
 {
     use Blameable;
-    use EntityAsset
-    ;
-    /**
-     * Traits
-     */
+    use EntityAsset;
     use VisibilityIDTrait;
 
     /** @var string[]  */
@@ -44,12 +40,6 @@ class EntityFile extends Model
     protected $isFile = true;
     protected $isLink = false;
     protected $isAlias = false;
-
-    /**
-     * Trigger for filtering based on the order request.
-     * @var string
-     */
-    protected $orderTrigger = 'files/';
 
     /**
      * Searchable fields

--- a/app/Models/Journal.php
+++ b/app/Models/Journal.php
@@ -108,7 +108,7 @@ class Journal extends MiscModel
             'entity.image' => function ($sub) {
                 $sub->select('campaign_id', 'id', 'ext', 'focus_x', 'focus_y');
             },
-            'entity.calendarDateEvents',
+            'entity.calendarDate',
             'author',
             'location' => function ($sub) {
                 $sub->select('id', 'name');

--- a/app/Models/Journal.php
+++ b/app/Models/Journal.php
@@ -29,8 +29,7 @@ use Illuminate\Database\Eloquent\Builder;
  */
 class Journal extends MiscModel
 {
-    use Acl
-    ;
+    use Acl;
     use CalendarDateTrait;
     use CampaignTrait;
     use ExportableTrait;

--- a/app/Models/Journal.php
+++ b/app/Models/Journal.php
@@ -51,12 +51,6 @@ class Journal extends MiscModel
         'is_private',
         'journal_id',
         'author_id',
-
-        // calendar date
-        'calendar_id',
-        'calendar_year',
-        'calendar_month',
-        'calendar_day',
     ];
 
     /**
@@ -91,6 +85,11 @@ class Journal extends MiscModel
         'calendar_id',
         'journal_id',
         'author_id',
+    ];
+
+    protected array $apiWith = [
+        'author',
+        'entity.calendarDate',
     ];
 
     /**

--- a/app/Models/Map.php
+++ b/app/Models/Map.php
@@ -157,6 +157,9 @@ class Map extends MiscModel
             'entity' => function ($sub) {
                 $sub->select('id', 'name', 'entity_id', 'type_id', 'image_uuid', 'focus_x', 'focus_y');
             },
+            'entity.image' => function ($sub) {
+                $sub->select('campaign_id', 'id', 'ext', 'focus_x', 'focus_y');
+            },
             'map' => function ($sub) {
                 $sub->select('id', 'name');
             },

--- a/app/Models/MenuLink.php
+++ b/app/Models/MenuLink.php
@@ -101,6 +101,10 @@ class MenuLink extends MiscModel
         'dashboard_id',
     ];
 
+    protected array $apiWith = [
+        'target',
+    ];
+
     /**
      * Set to false if this entity type doesn't have relations
      * @var bool

--- a/app/Models/Quest.php
+++ b/app/Models/Quest.php
@@ -48,12 +48,6 @@ class Quest extends MiscModel
         'character_id',
         'is_completed',
         'date',
-
-        // calendar date
-        'calendar_id',
-        'calendar_year',
-        'calendar_month',
-        'calendar_day',
     ];
 
     protected $sortable = [
@@ -96,6 +90,11 @@ class Quest extends MiscModel
      * @var array
      */
     protected $foreignExport = [
+        'elements',
+    ];
+
+    protected array $apiWith = [
+        'entity.calendarDate',
         'elements',
     ];
 

--- a/app/Models/Relations/CampaignRelations.php
+++ b/app/Models/Relations/CampaignRelations.php
@@ -235,7 +235,8 @@ trait CampaignRelations
      */
     public function menuLinks()
     {
-        return $this->hasMany(MenuLink::class);
+        return $this->hasMany(MenuLink::class)
+            ->with(['dashboard']);
     }
 
     /**

--- a/app/Models/Relations/EntityRelations.php
+++ b/app/Models/Relations/EntityRelations.php
@@ -408,12 +408,16 @@ trait EntityRelations
      */
     public function calendarDateEvents()
     {
-        return $this->events()->with('calendar')->calendarDate();
+        return $this->events()
+            ->with('calendar')
+            ->has('calendar')
+            ->calendarDate();
     }
 
     public function calendarDate() {
         return $this->hasOne('App\Models\EntityEvent', 'entity_id', 'id')
             ->with('calendar')
+            ->has('calendar')
             ->where('type_id', EntityEventType::CALENDAR_DATE);
     }
 

--- a/app/Models/Relations/EntityRelations.php
+++ b/app/Models/Relations/EntityRelations.php
@@ -7,10 +7,12 @@ use App\Models\Campaign;
 use App\Models\CampaignDashboardWidget;
 use App\Models\CampaignPermission;
 use App\Models\Conversation;
+use App\Models\Creature;
 use App\Models\EntityAbility;
 use App\Models\EntityAlias;
 use App\Models\EntityAsset;
 use App\Models\EntityEvent;
+use App\Models\EntityEventType;
 use App\Models\EntityLink;
 use App\Models\EntityMention;
 use App\Models\EntityNote;
@@ -23,6 +25,7 @@ use App\Models\Map;
 use App\Models\MiscModel;
 use App\Models\Post;
 use App\Models\Quest;
+use App\Models\Race;
 use App\Models\Relation;
 use App\Models\Tag;
 use App\Models\Timeline;
@@ -60,6 +63,7 @@ use Illuminate\Database\Eloquent\Collection;
  * @property Relation[]|Collection $relations
  * @property EntityEvent[]|Collection $elapsedEvents
  * @property EntityEvent[]|Collection $calendarDateEvents
+ * @property EntityEvent|null $calendarDate
  * @property Image|null $image
  * @property Image|null $header
  * @property User[]|Collection $users
@@ -405,6 +409,12 @@ trait EntityRelations
     public function calendarDateEvents()
     {
         return $this->events()->with('calendar')->calendarDate();
+    }
+
+    public function calendarDate() {
+        return $this->hasOne('App\Models\EntityEvent', 'entity_id', 'id')
+            ->with('calendar')
+            ->where('type_id', EntityEventType::CALENDAR_DATE);
     }
 
     /**

--- a/app/Models/Scopes/EntityScopes.php
+++ b/app/Models/Scopes/EntityScopes.php
@@ -168,8 +168,11 @@ trait EntityScopes
 
         return $query
             ->with($related ? [
-                'attributes', 'posts', 'posts.permissions', 'events',
-                'relationships', 'inventories', 'abilities',
+                'attributes', 'attributes.entity',
+                'posts', 'posts.permissions', 'posts.entity',
+                'events', 'events.entity',
+                'inventories', 'inventories.entity',
+                'relationships', 'abilities',
                 'tags', 'image', 'assets',
             ] : ['tags', 'image'])
         ;

--- a/app/Models/Timeline.php
+++ b/app/Models/Timeline.php
@@ -79,6 +79,11 @@ class Timeline extends MiscModel
      */
     protected $entityType = 'timeline';
 
+    protected array $apiWith = [
+        'eras',
+        'eras.elements',
+    ];
+
     /**
      * Performance with for datagrids
      * @param Builder $query

--- a/app/Policies/CampaignUserPolicy.php
+++ b/app/Policies/CampaignUserPolicy.php
@@ -49,7 +49,7 @@ class CampaignUserPolicy
         if (Identity::isImpersonating()) {
             return false;
         }
-        if ($user->campaign->id !== $campaignUser->campaign->id) {
+        if ($user->campaign->id !== $campaignUser->campaign_id) {
             return false;
         }
 
@@ -96,7 +96,7 @@ class CampaignUserPolicy
         if (Identity::isImpersonating()) {
             return false;
         }
-        return $user->campaign->id == $campaignUser->campaign->id
+        return $user->campaign->id == $campaignUser->campaign_id
             && $user->isAdmin() && !$campaignUser->user->isAdmin()
             && !$campaignUser->user->isBanned()
         ;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -72,6 +72,7 @@ use App\Observers\UserObserver;
 use App\Models\Organisation;
 use App\Models\OrganisationMember;
 use App\User;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Validator;
@@ -93,6 +94,10 @@ class AppServiceProvider extends ServiceProvider
 
         $this->registerWebObservers();
         Cashier::useCustomerModel(User::class);
+
+        if (config('app.lazy')) {
+            Model::preventLazyLoading();
+        }
 
         Validator::resolver(function ($translator, $data, $rules, $messages) {
             return new HashValidator($translator, $data, $rules, $messages);

--- a/app/Renderers/DatagridRenderer.php
+++ b/app/Renderers/DatagridRenderer.php
@@ -410,8 +410,8 @@ class DatagridRenderer
             } elseif ($type == 'calendar_date') {
                 $class = 'hidden-xs hidden-sm';
                 /** @var Journal $model */
-                if ($model->hasCalendar()) {
-                    $reminder = $model->calendarReminder();
+                if ($model->entity->calendarDate) {
+                    $reminder = $model->entity->calendarDate;
                     $content = link_to_route(
                         'calendars.show',
                         $reminder->readableDate(),

--- a/app/Services/EntityService.php
+++ b/app/Services/EntityService.php
@@ -254,6 +254,7 @@ class EntityService
             // relations and, since they won't make sense on the new campaign.
             $entity->relationships()->delete();
             $entity->targetRelationships()->delete();
+            $entity->events()->delete();
 
             // Get the child of the entity (the actual Location, Character etc) and remove the permissions, since they
             // won't make sense on the new campaign either.

--- a/app/Services/PermissionService.php
+++ b/app/Services/PermissionService.php
@@ -580,7 +580,11 @@ class PermissionService
     public function users()
     {
         if ($this->users === false) {
-            $this->users = $this->campaign->members()->withoutAdmins()->with('user')->get();
+            $this->users = $this->campaign
+                ->members()
+                ->withoutAdmins()
+                ->with(['user', 'user.campaignRoles'])
+                ->get();
         }
         return $this->users;
     }

--- a/app/Traits/CalendarDateTrait.php
+++ b/app/Traits/CalendarDateTrait.php
@@ -33,12 +33,12 @@ trait CalendarDateTrait
      */
     public function hasCalendar(): bool
     {
-        return $this->entity->calendarDate && $this->entity->calendarDate->calendar !== null;
+        return $this->hasCalendarDate() && $this->entity->calendarDate->calendar !== null;
     }
 
     public function hasCalendarButNoAccess(): bool
     {
-        return $this->entity->calendarDate && $this->entity->calendarDate->calendar === null;
+        return $this->hasCalendarDate() && $this->entity->calendarDate->calendar === null;
     }
 
     /**
@@ -71,7 +71,7 @@ trait CalendarDateTrait
      */
     public function getCalendarIdAttribute(): int|null
     {
-        if (!$this->entity->calendarDate) {
+        if (!$this->hasCalendarDate()) {
             return null;
         }
         return $this->entity->calendarDate->calendar_id;
@@ -82,7 +82,7 @@ trait CalendarDateTrait
      */
     public function getCalendarYearAttribute(): int|null
     {
-        if (!$this->entity->calendarDate) {
+        if (!$this->hasCalendarDate()) {
             return null;
         }
         return $this->entity->calendarDate->year;
@@ -93,7 +93,7 @@ trait CalendarDateTrait
      */
     public function getCalendarMonthAttribute(): int|null
     {
-        if (!$this->entity->calendarDate) {
+        if (!$this->hasCalendarDate()) {
             return null;
         }
         return $this->entity->calendarDate->month;
@@ -104,7 +104,7 @@ trait CalendarDateTrait
      */
     public function getCalendarDayAttribute(): int|null
     {
-        if (!$this->entity->calendarDate) {
+        if (!$this->hasCalendarDate()) {
             return null;
         }
         return $this->entity->calendarDate->day;
@@ -115,7 +115,7 @@ trait CalendarDateTrait
      */
     public function getCalendarLengthAttribute(): int|null
     {
-        if (!$this->entity->calendarDate) {
+        if (!$this->hasCalendarDate()) {
             return null;
         }
         return (int) $this->entity->calendarDate->length;
@@ -126,7 +126,7 @@ trait CalendarDateTrait
      */
     public function getCalendarIsRecurringAttribute(): bool
     {
-        return $this->entity->calendarDate ? $this->entity->calendarDate->is_recurring : false;
+        return $this->hasCalendarDate() ? $this->entity->calendarDate->is_recurring : false;
     }
 
     /**
@@ -135,7 +135,7 @@ trait CalendarDateTrait
      */
     public function getCalendarRecurringPeriodicityAttribute(): string|null
     {
-        if (!$this->entity->calendarDate) {
+        if (!$this->hasCalendarDate()) {
             return null;
         }
         return $this->entity->calendarDate->recurring_periodicity;
@@ -147,7 +147,7 @@ trait CalendarDateTrait
      */
     public function getCalendarColourAttribute()
     {
-        if (!$this->entity->calendarDate) {
+        if (!$this->hasCalendarDate()) {
             return '#cccccc';
         }
         return $this->entity->calendarDate->colour;
@@ -156,5 +156,10 @@ trait CalendarDateTrait
     public function calendarReminder(): null|EntityEvent
     {
         return $this->entity?->calendarDate;
+    }
+
+    protected function hasCalendarDate(): bool
+    {
+        return $this->entity && $this->entity->calendarDate;
     }
 }

--- a/app/Traits/CalendarDateTrait.php
+++ b/app/Traits/CalendarDateTrait.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Arr;
  * @package App\Traits
  *
  * @property EntityEvent $calendarReminder
+ * @property EntityEvent|null $calendarDate
  * @property int|null $calendar_id
  * @property int|null $calendar_year
  * @property int|null $calendar_month
@@ -19,9 +20,6 @@ use Illuminate\Support\Arr;
  */
 trait CalendarDateTrait
 {
-    /** @var bool|null|EntityEvent */
-    protected $calendarDateEvent = false;
-
     /**
      * On boot of the trait, inject the fillable fields.
      */
@@ -35,12 +33,13 @@ trait CalendarDateTrait
      */
     public function hasCalendar(): bool
     {
-        return $this->calendarReminder() !== null && $this->calendarReminder()->calendar !== null;
+        dump($this->entity->calendarDate);
+        return $this->entity->calendarDate && $this->calendarDate->calendar !== null;
     }
 
     public function hasCalendarButNoAccess(): bool
     {
-        return $this->calendarReminder() !== null && $this->calendarReminder()->calendar === null;
+        return $this->calendarDate && $this->calendarDate->calendar === null;
     }
 
     /**
@@ -48,7 +47,7 @@ trait CalendarDateTrait
      */
     public function getDate(): string
     {
-        $reminder = $this->calendarReminder();
+        $reminder = $this->calendarDate;
         $months = $reminder->calendar->months();
         $count = 0;
         $monthCount = 1;
@@ -73,10 +72,10 @@ trait CalendarDateTrait
      */
     public function getCalendarIdAttribute(): int|null
     {
-        if (!$this->calendarReminder()) {
+        if (!$this->calendarDate) {
             return null;
         }
-        return $this->calendarReminder()->calendar_id;
+        return $this->calendarDate->calendar_id;
     }
 
     /**
@@ -84,10 +83,10 @@ trait CalendarDateTrait
      */
     public function getCalendarYearAttribute(): int|null
     {
-        if (!$this->calendarReminder()) {
+        if (!$this->calendarDate) {
             return null;
         }
-        return $this->calendarReminder()->year;
+        return $this->calendarDate->year;
     }
 
     /**
@@ -95,10 +94,10 @@ trait CalendarDateTrait
      */
     public function getCalendarMonthAttribute(): int|null
     {
-        if (!$this->calendarReminder()) {
+        if (!$this->calendarDate) {
             return null;
         }
-        return $this->calendarReminder()->month;
+        return $this->calendarDate->month;
     }
 
     /**
@@ -106,10 +105,10 @@ trait CalendarDateTrait
      */
     public function getCalendarDayAttribute(): int|null
     {
-        if (!$this->calendarReminder()) {
+        if (!$this->calendarDate) {
             return null;
         }
-        return $this->calendarReminder()->day;
+        return $this->calendarDate->day;
     }
 
     /**
@@ -117,10 +116,10 @@ trait CalendarDateTrait
      */
     public function getCalendarLengthAttribute(): int|null
     {
-        if (!$this->calendarReminder()) {
+        if (!$this->calendarDate) {
             return null;
         }
-        return (int) $this->calendarReminder()->length;
+        return (int) $this->calendarDate->length;
     }
 
     /**
@@ -128,7 +127,7 @@ trait CalendarDateTrait
      */
     public function getCalendarIsRecurringAttribute(): bool
     {
-        return $this->calendarReminder() ? $this->calendarReminder()->is_recurring : false;
+        return $this->calendarDate ? $this->calendarDate->is_recurring : false;
     }
 
     /**
@@ -137,10 +136,10 @@ trait CalendarDateTrait
      */
     public function getCalendarRecurringPeriodicityAttribute(): string|null
     {
-        if (!$this->calendarReminder()) {
+        if (!$this->calendarDate) {
             return null;
         }
-        return $this->calendarReminder()->recurring_periodicity;
+        return $this->calendarDate->recurring_periodicity;
     }
 
     /**
@@ -149,29 +148,9 @@ trait CalendarDateTrait
      */
     public function getCalendarColourAttribute()
     {
-        if (!$this->calendarReminder()) {
+        if (!$this->calendarDate) {
             return '#cccccc';
         }
-        return $this->calendarReminder()->colour;
-    }
-
-    /**
-     * Refactor July 2022
-     * Get the reminder associated to the entity's "calendar date"
-     */
-    public function calendarReminder(): null|EntityEvent
-    {
-        if ($this->calendarDateEvent !== false) {
-            return $this->calendarDateEvent;
-        }
-        if (!$this->entity) {
-            return $this->calendarDateEvent = null;
-        }
-        $this->calendarDateEvent = $this->entity->calendarDateEvents->first();
-        if (!$this->calendarDateEvent || !$this->calendarDateEvent->calendar) {
-            return $this->calendarDateEvent = null;
-        }
-
-        return $this->calendarDateEvent;
+        return $this->calendarDate->colour;
     }
 }

--- a/app/Traits/CalendarDateTrait.php
+++ b/app/Traits/CalendarDateTrait.php
@@ -33,13 +33,12 @@ trait CalendarDateTrait
      */
     public function hasCalendar(): bool
     {
-        dump($this->entity->calendarDate);
-        return $this->entity->calendarDate && $this->calendarDate->calendar !== null;
+        return $this->entity->calendarDate && $this->entity->calendarDate->calendar !== null;
     }
 
     public function hasCalendarButNoAccess(): bool
     {
-        return $this->calendarDate && $this->calendarDate->calendar === null;
+        return $this->entity->calendarDate && $this->entity->calendarDate->calendar === null;
     }
 
     /**
@@ -72,10 +71,10 @@ trait CalendarDateTrait
      */
     public function getCalendarIdAttribute(): int|null
     {
-        if (!$this->calendarDate) {
+        if (!$this->entity->calendarDate) {
             return null;
         }
-        return $this->calendarDate->calendar_id;
+        return $this->entity->calendarDate->calendar_id;
     }
 
     /**
@@ -83,10 +82,10 @@ trait CalendarDateTrait
      */
     public function getCalendarYearAttribute(): int|null
     {
-        if (!$this->calendarDate) {
+        if (!$this->entity->calendarDate) {
             return null;
         }
-        return $this->calendarDate->year;
+        return $this->entity->calendarDate->year;
     }
 
     /**
@@ -94,10 +93,10 @@ trait CalendarDateTrait
      */
     public function getCalendarMonthAttribute(): int|null
     {
-        if (!$this->calendarDate) {
+        if (!$this->entity->calendarDate) {
             return null;
         }
-        return $this->calendarDate->month;
+        return $this->entity->calendarDate->month;
     }
 
     /**
@@ -105,10 +104,10 @@ trait CalendarDateTrait
      */
     public function getCalendarDayAttribute(): int|null
     {
-        if (!$this->calendarDate) {
+        if (!$this->entity->calendarDate) {
             return null;
         }
-        return $this->calendarDate->day;
+        return $this->entity->calendarDate->day;
     }
 
     /**
@@ -116,10 +115,10 @@ trait CalendarDateTrait
      */
     public function getCalendarLengthAttribute(): int|null
     {
-        if (!$this->calendarDate) {
+        if (!$this->entity->calendarDate) {
             return null;
         }
-        return (int) $this->calendarDate->length;
+        return (int) $this->entity->calendarDate->length;
     }
 
     /**
@@ -127,7 +126,7 @@ trait CalendarDateTrait
      */
     public function getCalendarIsRecurringAttribute(): bool
     {
-        return $this->calendarDate ? $this->calendarDate->is_recurring : false;
+        return $this->entity->calendarDate ? $this->entity->calendarDate->is_recurring : false;
     }
 
     /**
@@ -136,10 +135,10 @@ trait CalendarDateTrait
      */
     public function getCalendarRecurringPeriodicityAttribute(): string|null
     {
-        if (!$this->calendarDate) {
+        if (!$this->entity->calendarDate) {
             return null;
         }
-        return $this->calendarDate->recurring_periodicity;
+        return $this->entity->calendarDate->recurring_periodicity;
     }
 
     /**
@@ -148,9 +147,14 @@ trait CalendarDateTrait
      */
     public function getCalendarColourAttribute()
     {
-        if (!$this->calendarDate) {
+        if (!$this->entity->calendarDate) {
             return '#cccccc';
         }
-        return $this->calendarDate->colour;
+        return $this->entity->calendarDate->colour;
+    }
+
+    public function calendarReminder(): null|EntityEvent
+    {
+        return $this->entity?->calendarDate;
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -52,6 +52,7 @@ use App\Models\Concerns\LastSync;
  * @property Carbon|string|null $created_at
  * @property Collection|array $settings
  * @property Collection|array $profile
+ * @property Campaign $campaign
  *
  * Virtual (from \App\Models\UserSetting)
  * @property bool $advancedMentions

--- a/config/app.php
+++ b/config/app.php
@@ -155,6 +155,9 @@ return [
      */
     'force_https' => env('APP_FORCE_HTTPS', false),
 
+
+    'lazy' => env('APP_LAZY', false),
+
     /*
     |--------------------------------------------------------------------------
     | Autoloaded Service Providers

--- a/resources/views/entities/components/profile/_reminder.blade.php
+++ b/resources/views/entities/components/profile/_reminder.blade.php
@@ -1,7 +1,7 @@
 @if ($model->calendarReminder())
     <div class="element profile-date">
         <div class="title text-uppercase text-xs">{{ __('crud.fields.calendar_date') }}</div>
-        <a href="{{ route('calendars.show', [$model->calendar_id, 'year' => $model->calendarReminder()->year, 'month' => $model->calendarReminder()->month]) }}">
+        <a href="{{ route('calendars.show', [$model->entity->calendarDate->calendar_id, 'year' => $model->calendarReminder()->year, 'month' => $model->calendarReminder()->month]) }}">
             {{ $model->calendarReminder()->readableDate() }}
         </a>
     </div>


### PR DESCRIPTION
Instead of duplicating data on the journal|quest, it's not directly loaded from the calendar date with a unique `type_id`. This PR also fixes many lazy loading issues on the API