### PR TITLE
Small change to be able to set custom url for OpenAI API

### DIFF
--- a/app/Services/Bragi/OpenAiService.php
+++ b/app/Services/Bragi/OpenAiService.php
@@ -37,6 +37,8 @@ class OpenAiService
         $token = config('openai.secret');
         $openAi = new OpenAi($token);
 
+        $openAi->setCustomURL(config('openai.custom_url'));
+
         //Creating prompt
         $prompt = $this->preparePrompt();
 

--- a/config/openai.php
+++ b/config/openai.php
@@ -8,6 +8,11 @@ return [
     'secret' => env('OPEN_AI_SECRET', 0),
 
     /**
+     * Custom URL
+     */
+    'custom_url' => env('OPEN_AI_URL', ''),
+
+    /**
      * AI model to use.
      *
      * Available models:

--- a/lang/en/openai.php
+++ b/lang/en/openai.php
@@ -3,7 +3,7 @@
 return [
     /** Without "fantasy", the bias is more towards the modern world. The setting might need to be user controlled */
     //'intro' => 'Write three paragraphs about a fantasy character.',
-    'intro' => 'You\'re the best professional writter who will write three paragraphs about a fantasy character inspired by the provided characteristics and prompt.',
+    'intro' => 'You\'re the best professional writer who will write three paragraphs about a fantasy character inspired by the provided characteristics and prompt.',
     'intro-named' => 'The character is named :name.',
     'intro-gender' => 'The character\'s gender is :gender.',
     'intro-pronouns' => 'The character\'s pronouns are :pronouns, use these when refering to the character.',


### PR DESCRIPTION
To use with another service or with a local LLM.

Also, fixed a typo in lang file.

Usage in .env file
```OPEN_AI_URL=http://localhost:1234```

Not added to .env.example because `OPEN_AI_SECRET` also not in there.
